### PR TITLE
Configure CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,33 +5,68 @@ orbs:
   gh-pages: sugarshin/gh-pages@0.0.6
 
 executors:
+  base-executor:
+    docker:
+      - image: cimg/base:stable
+
   emscripten-executor:
     docker:
       - image: emscripten/emsdk:2.0.30
 
 jobs:
-  build-web:
-    executor: emscripten-executor
+  checkout-repo:
+    executor: base-executor
     steps:
       - checkout
       - run: git submodule update --recursive --init
+      - persist_to_workspace:
+          root: ~/
+          paths:
+            - project
+  build-web:
+    executor: emscripten-executor
+    steps:
+      - attach_workspace:
+          at: ~/
       - run: |
           mkdir build_web
           cd build_web
           emcmake cmake ../
           make deploy
       - persist_to_workspace:
-          root: build_web
+          root: ~/
           paths:
-            - deploy
+            - project/build_web/deploy
+
+  build-desktop:
+    executor: base-executor
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run: |
+          mkdir build_desktop
+          cd build_desktop
+          cmake ../
+          make
 
 workflows:
   build-web-deploy:
     jobs:
-      - build-web
+      - checkout-repo
+      - build-web:
+          requires:
+            - checkout-repo
+
+      - build-desktop:
+          pre-steps:
+            - run: sudo apt update
+            - run: sudo apt install cmake libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev
+          requires:
+            - checkout-repo
+
       - gh-pages/deploy:
           attach-workspace: true
-          workspace-root: build_web
+          workspace-root: ~/
           build-dir: build_web/deploy
           requires:
             - build-web

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,42 @@
+# Use the latest 2.1 version of CircleCI pipeline process engine. See: https://circleci.com/docs/2.0/configuration-reference
+version: 2.1
+# Use a package of configuration called an orb.
+orbs:
+  gh-pages: sugarshin/gh-pages@0.0.6
+
+executors:
+  emscripten-executor:
+    docker:
+      - image: emscripten/emsdk:2.0.30
+
+jobs:
+  build-web:
+    executor: emscripten-executor
+    steps:
+      - checkout
+      - run: git submodule update --recursive --init
+      - run: |
+          mkdir build_web
+          cd build_web
+          emcmake cmake ../
+          make deploy
+      - persist_to_workspace:
+          root: build_web
+          paths:
+            - deploy
+
+workflows:
+  build-web-deploy:
+    jobs:
+      - build-web
+      - gh-pages/deploy:
+          attach-workspace: true
+          workspace-root: build_web
+          build-dir: build_web/deploy
+          requires:
+            - build-web
+          ssh-fingerprints: 'a4:8c:85:7f:e5:78:d0:3d:b3:f4:9b:e1:bd:14:db:1b'
+          filters:
+            branches:
+              only:
+                - main

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # 2D-robot-simulator
+[![CircleCI](https://circleci.com/gh/lawyiu/2D-robot-simulator/tree/main.svg?style=shield)](https://circleci.com/gh/lawyiu/2D-robot-simulator/tree/main)
+
 A 2 dimensional top down robot simulator designed to allow users to run their Arduino code on a virtual robot.
 
 Try out the [web demo](https://lawyiu.github.io/2D-robot-simulator/)!


### PR DESCRIPTION
Use CircleCI to build web and desktop versions of the 2D Robot Simulator as well as deploying the web version to GitHub Pages.